### PR TITLE
Feature/18 loader - 로더 처리하기

### DIFF
--- a/features/enforcement/EnforceScene.tsx
+++ b/features/enforcement/EnforceScene.tsx
@@ -5,7 +5,7 @@ import { GLTFLoader } from 'three/examples/jsm/Addons.js';
 import Handler from './components/Handler';
 
 export default function EnforceScene() {
-  const glb = useLoader(GLTFLoader, '/hammer.glb');
+  // const glb = useLoader(GLTFLoader, '/hammer.glb');
   const glb2 = useLoader(GLTFLoader, '/shiba.glb');
 
   return (

--- a/features/enforcement/EnforceScene.tsx
+++ b/features/enforcement/EnforceScene.tsx
@@ -3,6 +3,7 @@
 import { useLoader } from '@react-three/fiber';
 import { GLTFLoader } from 'three/examples/jsm/Addons.js';
 import Handler from './components/Handler';
+import { Suspense } from 'react';
 
 export default function EnforceScene() {
   // const glb = useLoader(GLTFLoader, '/hammer.glb');

--- a/shared/components/3dmodel/index.tsx
+++ b/shared/components/3dmodel/index.tsx
@@ -2,6 +2,7 @@
 
 import { Loader, OrbitControls } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
+import { Suspense } from 'react';
 
 export default function CanvasLayout({
   children,
@@ -11,14 +12,16 @@ export default function CanvasLayout({
   return (
     <>
       <Canvas camera={{ position: [0, 0, 5], fov: 45 }}>
-        <color attach="background" args={['rgb(195, 195, 195) 100%)']} />
-        <OrbitControls
-          makeDefault
-          enablePan={false}
-          minDistance={2}
-          maxDistance={15}
-        />
-        {children}
+        <Suspense fallback={null}>
+          <color attach="background" args={['rgb(195, 195, 195) 100%)']} />
+          <OrbitControls
+            makeDefault
+            enablePan={false}
+            minDistance={2}
+            maxDistance={15}
+          />
+          {children}
+        </Suspense>
       </Canvas>
       <Loader />
     </>

--- a/shared/components/3dmodel/index.tsx
+++ b/shared/components/3dmodel/index.tsx
@@ -12,16 +12,16 @@ export default function CanvasLayout({
   return (
     <>
       <Canvas camera={{ position: [0, 0, 5], fov: 45 }}>
-        <Suspense fallback={null}>
-          <color attach="background" args={['rgb(195, 195, 195) 100%)']} />
-          <OrbitControls
-            makeDefault
-            enablePan={false}
-            minDistance={2}
-            maxDistance={15}
-          />
-          {children}
-        </Suspense>
+        <color attach="background" args={['rgb(195, 195, 195) 100%)']} />
+        <OrbitControls
+          makeDefault
+          enablePan={false}
+          minDistance={2}
+          maxDistance={15}
+        />
+        <>
+          <Suspense fallback={null}>{children}</Suspense>
+        </>
       </Canvas>
       <Loader />
     </>


### PR DESCRIPTION
1. glb파일을 로딩할 때 시간이 많이 걸리므로 로딩처리
2. 에러사항 : drei의 loader 컴퍼넌트를 사용할 경우 Suspense랑 같은 컴퍼넌트에 존재하지 않으면 인식하지 못함.
3. TODO : Loader가 유의미 하다 생각하지 않음.. ssr된 헤더 컴퍼넌트가 먼저 로딩되고 , 로더가 화면 전체를 가림